### PR TITLE
OCS: Set desired permissions explicitly when sharing with user

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_install:
   - nvm install 8.9
   - cd ../..
   - composer selfupdate
-  - composer create-project -n --no-dev --prefer-dist blackboard-open-source/moodle-plugin-ci ci ^2
+  - composer create-project -n --no-dev --prefer-dist blackboard-open-source/moodle-plugin-ci ci dev-master
   - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,9 @@ cache:
 
 addons:
   postgresql: "9.4"
-  apt:
-    packages:
-      - oracle-java9-installer
-      - oracle-java9-set-default
 
+services:
+  - mysql
 
 php:
   - 7.0
@@ -25,9 +23,11 @@ env:
   matrix:
    - DB=pgsql MOODLE_BRANCH=MOODLE_35_STABLE
    - DB=pgsql MOODLE_BRANCH=MOODLE_36_STABLE
+   - DB=pgsql MOODLE_BRANCH=MOODLE_37_STABLE
    - DB=pgsql MOODLE_BRANCH=master
    - DB=mysqli MOODLE_BRANCH=MOODLE_35_STABLE
    - DB=mysqli MOODLE_BRANCH=MOODLE_36_STABLE
+   - DB=mysqli MOODLE_BRANCH=MOODLE_37_STABLE
    - DB=mysqli MOODLE_BRANCH=master
 
 matrix:
@@ -39,6 +39,10 @@ matrix:
     env: DB=mysqli MOODLE_BRANCH=MOODLE_35_STABLE
   - php: 7.3
     env: DB=pgsql MOODLE_BRANCH=MOODLE_35_STABLE
+  - php: 7.0
+    env: DB=pgsql MOODLE_BRANCH=MOODLE_37_STABLE
+  - php: 7.0
+    env: DB=mysqli MOODLE_BRANCH=MOODLE_37_STABLE
   - php: 7.0
     env: DB=pgsql MOODLE_BRANCH=master
   - php: 7.0
@@ -57,8 +61,8 @@ jobs:
   include:
     # Prechecks against latest Moodle stable only.
     - stage: static
-      php: 7.1
-      env: DB=mysqli MOODLE_BRANCH=MOODLE_36_STABLE
+      php: 7.3
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_37_STABLE
       install:
       - moodle-plugin-ci install --no-init
       script:
@@ -72,8 +76,8 @@ jobs:
       - moodle-plugin-ci validate
     # Smaller build matrix for development builds
     - stage: develop
-      php: 7.2
-      env: DB=mysqli MOODLE_BRANCH=MOODLE_36_STABLE
+      php: 7.3
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_37_STABLE
       script:
       - moodle-plugin-ci phpunit --coverage-clover
       - moodle-plugin-ci behat

--- a/classes/local/clients/system_folder_access.php
+++ b/classes/local/clients/system_folder_access.php
@@ -191,12 +191,13 @@ class system_folder_access {
             'path' => $path,
             'shareType' => ocs_client::SHARE_TYPE_USER,
             'shareWith' => $username,
+            'permissions' => ocs_client::SHARE_PERMISSION_ALL, // (Read, update, create, delete, share).
         ];
         if ($chosenname !== null) {
             $chosenname = \core_text::substr($chosenname, 0, 64); // Make sure the name is <= 64 characters.
             $params['name'] = $chosenname;
         }
-        $response = $this->ocsclient->call('create_share', $params); // TODO consider permissions (default vs. wanted).
+        $response = $this->ocsclient->call('create_share', $params);
 
         $xml = simplexml_load_string($response);
 

--- a/classes/ocs_client.php
+++ b/classes/ocs_client.php
@@ -56,7 +56,7 @@ class ocs_client extends rest {
     const SHARE_PERMISSION_READ = 1;
 
     /**
-     * permissions=1 gives read permission for a share.
+     * permissions=31 gives all permissions for a share: 1 = read; 2 = update; 4 = create; 8 = delete; 16 = share.
      */
     const SHARE_PERMISSION_ALL = 31;
 

--- a/settings.php
+++ b/settings.php
@@ -53,16 +53,18 @@ if ($ADMIN->fulltree) {
     // Indicate quality of the chosen issuer.
     // Warning if no issuer chosen / issuer invalid / issuer valid but no system account connected.
     $issuerid = get_config("collaborativefolders", "issuerid");
-    $issuer = \core\oauth2\api::get_issuer($issuerid);
 
     if (empty($issuerid) || !array_key_exists($issuerid, $availableissuers)) {
         $issuervalidation = get_string('issuervalidation_without', 'mod_collaborativefolders');
     } else if (!in_array($issuerid, $validissuers)) {
         $issuervalidation = get_string('issuervalidation_invalid', 'mod_collaborativefolders', $availableissuers[$issuerid]);
-    } else if (!$issuer->is_system_account_connected()) {
-        $issuervalidation = get_string('issuervalidation_notconnected', 'mod_collaborativefolders', $availableissuers[$issuerid]);
     } else {
-        $issuervalidation = get_string('issuervalidation_valid', 'mod_collaborativefolders', $availableissuers[$issuerid]);
+        $issuer = \core\oauth2\api::get_issuer($issuerid);
+        if (!$issuer->is_system_account_connected()) {
+            $issuervalidation = get_string('issuervalidation_notconnected', 'mod_collaborativefolders', $availableissuers[$issuerid]);
+        } else {
+            $issuervalidation = get_string('issuervalidation_valid', 'mod_collaborativefolders', $availableissuers[$issuerid]);
+        }
     }
 
     // Render the form.


### PR DESCRIPTION
Haven't tested this yet, but it should fix the problem that users don't have any permissions. Could you please try this out @moodlebeuth ? (and maybe revert if it causes more problems...)

If the folder has already been shared with you, remove the share manually first (i.e., enter your personal Nextcloud and delete the folder that has been shared with you.) We don't try and fix existing shares.